### PR TITLE
expose register read/write functions in public API

### DIFF
--- a/include/ads1115.h
+++ b/include/ads1115.h
@@ -98,6 +98,9 @@ void ads1115_set_max_ticks(ads1115_t* ads, TickType_t max_ticks); // maximum wai
 int16_t ads1115_get_raw(ads1115_t* ads); // get voltage in bits
 double ads1115_get_voltage(ads1115_t* ads); // get voltage in volts
 
+esp_err_t ads1115_write_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint16_t data);
+esp_err_t ads1115_read_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint8_t* data, uint8_t len);
+
 #endif // ifdef ADS1115_H
 
 #ifdef __cplusplus

--- a/src/ads1115.c
+++ b/src/ads1115.c
@@ -11,7 +11,7 @@ static void IRAM_ATTR gpio_isr_handler(void* arg) {
   xQueueSendFromISR(gpio_evt_queue, &ret, NULL);
 }
 
-static esp_err_t ads1115_write_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint16_t data) {
+esp_err_t ads1115_write_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint16_t data) {
   i2c_cmd_handle_t cmd;
   esp_err_t ret;
   uint8_t out[2];
@@ -30,7 +30,7 @@ static esp_err_t ads1115_write_register(ads1115_t* ads, ads1115_register_address
   return ret;
 }
 
-static esp_err_t ads1115_read_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint8_t* data, uint8_t len) {
+esp_err_t ads1115_read_register(ads1115_t* ads, ads1115_register_addresses_t reg, uint8_t* data, uint8_t len) {
   i2c_cmd_handle_t cmd;
   esp_err_t ret;
 


### PR DESCRIPTION
Make ads1115_write_register and ads1115_read_register functions public
by removing static qualifier and adding declarations to header file.
